### PR TITLE
Updated detailed diff algo to unordered

### DIFF
--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -12,37 +12,71 @@ Exit codes:
 
 import csv
 import sys
-from itertools import zip_longest
+from collections import Counter, defaultdict, deque
 
 
-def load(path: str) -> list[tuple]:
+def load(path: str) -> list[tuple[int, tuple]]:
+    """Load CSV rows as (1-based line number, row tuple), preserving original order."""
     with open(path, newline="") as f:
         reader = csv.DictReader(f)
         header = reader.fieldnames or []
-        rows = [tuple(row[col] for col in header) for row in reader]
-    return sorted(rows)
+        return [
+            (i, tuple(row[col] for col in header))
+            for i, row in enumerate(reader, start=1)
+        ]
 
 
 def diff(expected_path: str, actual_path: str) -> list[str]:
-    diffs = []
-    c_rows = load(expected_path)
-    g_rows = load(actual_path)
+    exp_rows = load(expected_path)
+    act_rows = load(actual_path)
 
-    if len(c_rows) != len(g_rows):
+    exp_content = [row for _, row in exp_rows]
+    act_content = [row for _, row in act_rows]
+
+    exp_counter = Counter(exp_content)
+    act_counter = Counter(act_content)
+    matched = exp_counter & act_counter  # rows present in both (min count)
+
+    unmatched_exp = exp_counter - matched  # rows only in expected
+    unmatched_act = act_counter - matched  # rows only in actual
+
+    if not unmatched_exp and not unmatched_act:
+        if exp_content != act_content:
+            return [
+                "Row order changed: rows are identical but appear in a different order"
+            ]
+        return []
+
+    # Build per-content queues of line numbers; consume matched rows first
+    # so remaining entries represent the truly unmatched lines.
+    exp_linenos: dict[tuple, deque[int]] = defaultdict(deque)
+    for lineno, row in exp_rows:
+        exp_linenos[row].append(lineno)
+
+    act_linenos: dict[tuple, deque[int]] = defaultdict(deque)
+    for lineno, row in act_rows:
+        act_linenos[row].append(lineno)
+
+    for row, count in matched.items():
+        for _ in range(count):
+            exp_linenos[row].popleft()
+            act_linenos[row].popleft()
+
+    diffs = []
+    if len(exp_content) != len(act_content):
         diffs.append(
-            f"Row count changed: {len(c_rows)} expected -> {len(g_rows)} actual"
+            f"Row count changed: {len(exp_content)} expected -> {len(act_content)} actual"
         )
 
-    _ABSENT = object()
-    for i, (c_row, g_row) in enumerate(
-        zip_longest(c_rows, g_rows, fillvalue=_ABSENT), start=1
-    ):
-        if c_row is _ABSENT:
-            diffs.append(f"  Row {i}: present in actual only -> {g_row}")
-        elif g_row is _ABSENT:
-            diffs.append(f"  Row {i}: present in expected only -> {c_row}")
-        elif c_row != g_row:
-            diffs.append(f"  Row {i}: expected={c_row} -> actual={g_row}")
+    for row in sorted(unmatched_exp):
+        for _ in range(unmatched_exp[row]):
+            lineno = exp_linenos[row].popleft()
+            diffs.append(f"  Expected row {lineno} not found in actual: {row}")
+
+    for row in sorted(unmatched_act):
+        for _ in range(unmatched_act[row]):
+            lineno = act_linenos[row].popleft()
+            diffs.append(f"  Actual row {lineno} not found in expected: {row}")
 
     return diffs
 

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -97,13 +97,13 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
     unmatched_exp = exp_counter - matched
     unmatched_act = act_counter - matched
 
-    # Uncomment this if we care about row order changes
-    # if not unmatched_exp and not unmatched_act:
-    #     if exp_content != act_content:
-    #         return [
-    #             "Row order changed: rows are identical but appear in a different order"
-    #         ]
-    #     return []
+    if not unmatched_exp and not unmatched_act:
+        # Uncomment this if we care about row order changes
+        # if exp_content != act_content:
+        #     return [
+        #         "Row order changed: rows are identical but appear in a different order"
+        #     ]
+        return []
 
     remaining_exp = _filter_unmatched(exp_rows, unmatched_exp)
     remaining_act = _filter_unmatched(act_rows, unmatched_act)

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -14,6 +14,8 @@ import csv
 import sys
 from collections import Counter
 
+from tabulate import tabulate
+
 
 def load(path: str) -> tuple[list[str], list[tuple[int, tuple]]]:
     """Return (header, [(1-based line number, row tuple)]), preserving original order."""
@@ -81,34 +83,10 @@ def _pair_closest(
     return pairs, unpaired_exp, unpaired_act
 
 
-def create_md_table(table_name, headers, records, property_getter=None):
-    """
-    Create a Markdown table with the given headers and records.
-
-    Args:
-        table_name: The title of the table
-        headers: List of column headers
-        records: List of records to include in the table
-        property_getter: Optional function to extract properties from records.
-                         If None, assumes records are dictionaries.
-    Returns:
-        String containing the formatted Markdown table
-    """
-    title = f"### {table_name}"
-    header = "| " + " | ".join(headers) + " |"
-    underline = "| " + " | ".join(["---" for _ in headers]) + " |"
-
-    if property_getter is None:
-
-        def property_getter(record, prop):
-            return str(record.get(prop, ""))
-
-    values = "\n".join(
-        "| " + " | ".join([property_getter(record, prop) for prop in headers]) + " |"
-        for record in records
-    )
-
-    return f"{title}\n\n{header}\n{underline}\n{values}"
+def _render_diff_table(table_name: str, headers: list[str], records: list[dict]) -> str:
+    rows = [[r.get(h, "") for h in headers] for r in records]
+    table = tabulate(rows, headers=headers, tablefmt="github")
+    return f"### {table_name}\n\n{table}"
 
 
 def diff(expected_path: str, actual_path: str) -> list[str]:
@@ -148,10 +126,10 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
     records = []
     for (exp_lineno, exp_row), (act_lineno, act_row) in pairs:
         exp_record = {"Exp/Act": "Expected", "Result Row": str(exp_lineno)}
-        act_record = {"Exp/Act": "Actual",   "Result Row": str(act_lineno)}
+        act_record = {"Exp/Act": "Actual", "Result Row": str(act_lineno)}
         for col, ev, av in zip(exp_header, exp_row, act_row):
-            exp_record[col] = f"**{ev}**" if ev != av else ev
-            act_record[col] = f"**{av}**" if ev != av else av
+            exp_record[col] = f"**{ev}**" if ev != av and ev != "" else ev
+            act_record[col] = f"**{av}**" if ev != av and av != "" else av
         records.append(exp_record)
         records.append(act_record)
 
@@ -165,7 +143,7 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
         record.update(zip(exp_header, row))
         records.append(record)
 
-    diffs.append(create_md_table("Diff Results", table_headers, records))
+    diffs.append(_render_diff_table("Diff Results", table_headers, records))
 
     return diffs
 

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -19,11 +19,11 @@ from tabulate import tabulate
 
 def load(path: str) -> tuple[list[str], list[tuple[int, tuple]]]:
     """Return (header, [(1-based line number, row tuple)]), preserving original order."""
-    with open(path, newline="", encoding="utf-8") as f:
+    with open(path, newline="") as f:
         reader = csv.DictReader(f)
         header = list(reader.fieldnames or [])
         rows = [
-            (i, tuple(row[col].strip("\r") for col in header))
+            (i, tuple(row[col] for col in header))
             for i, row in enumerate(reader, start=1)
         ]
     return header, rows

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -164,7 +164,7 @@ def main():
         sys.exit(2)
 
     if diffs:
-        print(f"### DIFF_FOUND for {case_label}:\n")
+        print(f"DIFF_FOUND for {case_label}:\n")
         for line in diffs:
             print(line)
         sys.exit(1)

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -97,12 +97,13 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
     unmatched_exp = exp_counter - matched
     unmatched_act = act_counter - matched
 
-    if not unmatched_exp and not unmatched_act:
-        if exp_content != act_content:
-            return [
-                "Row order changed: rows are identical but appear in a different order"
-            ]
-        return []
+    # Uncomment this if we care about row order changes
+    # if not unmatched_exp and not unmatched_act:
+    #     if exp_content != act_content:
+    #         return [
+    #             "Row order changed: rows are identical but appear in a different order"
+    #         ]
+    #     return []
 
     remaining_exp = _filter_unmatched(exp_rows, unmatched_exp)
     remaining_act = _filter_unmatched(act_rows, unmatched_act)

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -12,7 +12,7 @@ Exit codes:
 
 import csv
 import sys
-from collections import Counter, defaultdict, deque
+from collections import Counter
 
 
 def load(path: str) -> list[tuple[int, tuple]]:
@@ -24,6 +24,19 @@ def load(path: str) -> list[tuple[int, tuple]]:
             (i, tuple(row[col] for col in header))
             for i, row in enumerate(reader, start=1)
         ]
+
+
+def _filter_unmatched(
+    rows: list[tuple[int, tuple]], unmatched: Counter
+) -> list[tuple[int, tuple]]:
+    """Return rows (in original order) that belong to the unmatched set."""
+    remaining_counts = Counter(unmatched)
+    result = []
+    for lineno, row in rows:
+        if remaining_counts[row] > 0:
+            result.append((lineno, row))
+            remaining_counts[row] -= 1
+    return result
 
 
 def diff(expected_path: str, actual_path: str) -> list[str]:
@@ -47,20 +60,9 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
             ]
         return []
 
-    # Build per-content queues of line numbers; consume matched rows first
-    # so remaining entries represent the truly unmatched lines.
-    exp_linenos: dict[tuple, deque[int]] = defaultdict(deque)
-    for lineno, row in exp_rows:
-        exp_linenos[row].append(lineno)
-
-    act_linenos: dict[tuple, deque[int]] = defaultdict(deque)
-    for lineno, row in act_rows:
-        act_linenos[row].append(lineno)
-
-    for row, count in matched.items():
-        for _ in range(count):
-            exp_linenos[row].popleft()
-            act_linenos[row].popleft()
+    # Rebuild remaining unmatched rows in their original file order.
+    remaining_exp = _filter_unmatched(exp_rows, unmatched_exp)
+    remaining_act = _filter_unmatched(act_rows, unmatched_act)
 
     diffs = []
     if len(exp_content) != len(act_content):
@@ -68,15 +70,19 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
             f"Row count changed: {len(exp_content)} expected -> {len(act_content)} actual"
         )
 
-    for row in sorted(unmatched_exp):
-        for _ in range(unmatched_exp[row]):
-            lineno = exp_linenos[row].popleft()
-            diffs.append(f"  Expected row {lineno} not found in actual: {row}")
+    # Merge both unmatched lists by post-filter index; exp before act when tied.
+    # Sort key: (post_filter_row, 0=Expected/1=Actual)
+    entries = [
+        (post_idx, 0, "Expected", src_lineno, row)
+        for post_idx, (src_lineno, row) in enumerate(remaining_exp, start=1)
+    ] + [
+        (post_idx, 1, "Actual", src_lineno, row)
+        for post_idx, (src_lineno, row) in enumerate(remaining_act, start=1)
+    ]
+    entries.sort(key=lambda e: (e[0], e[1]))
 
-    for row in sorted(unmatched_act):
-        for _ in range(unmatched_act[row]):
-            lineno = act_linenos[row].popleft()
-            diffs.append(f"  Actual row {lineno} not found in expected: {row}")
+    for _, _, label, src_lineno, row in entries:
+        diffs.append(f"  [{label:8}] Row {src_lineno}: {row}")
 
     return diffs
 

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -83,12 +83,6 @@ def _pair_closest(
     return pairs, unpaired_exp, unpaired_act
 
 
-def _render_diff_table(table_name: str, headers: list[str], records: list[dict]) -> str:
-    rows = [[r.get(h, "") for h in headers] for r in records]
-    table = tabulate(rows, headers=headers, tablefmt="github")
-    return f"### {table_name}\n\n{table}"
-
-
 def diff(expected_path: str, actual_path: str) -> list[str]:
     exp_header, exp_rows = load(expected_path)
     _, act_rows = load(actual_path)
@@ -116,7 +110,7 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
     diffs = []
     if len(exp_content) != len(act_content):
         diffs.append(
-            f"Row count changed: {len(exp_content)} expected -> {len(act_content)} actual"
+            f"Row count changed: {len(exp_content)} expected -> {len(act_content)} actual\n"
         )
 
     pairs, unpaired_exp, unpaired_act = _pair_closest(remaining_exp, remaining_act)
@@ -143,7 +137,12 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
         record.update(zip(exp_header, row))
         records.append(record)
 
-    diffs.append(_render_diff_table("Diff Results", table_headers, records))
+    table = tabulate(
+        [[r.get(h, "") for h in table_headers] for r in records],
+        headers=table_headers,
+        tablefmt="github",
+    )
+    diffs.append(table)
 
     return diffs
 
@@ -165,7 +164,7 @@ def main():
         sys.exit(2)
 
     if diffs:
-        print(f"DIFF_FOUND for {case_label}:")
+        print(f"### DIFF_FOUND for {case_label}:\n")
         for line in diffs:
             print(line)
         sys.exit(1)

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -15,15 +15,16 @@ import sys
 from collections import Counter
 
 
-def load(path: str) -> list[tuple[int, tuple]]:
-    """Load CSV rows as (1-based line number, row tuple), preserving original order."""
+def load(path: str) -> tuple[list[str], list[tuple[int, tuple]]]:
+    """Return (header, [(1-based line number, row tuple)]), preserving original order."""
     with open(path, newline="") as f:
         reader = csv.DictReader(f)
-        header = reader.fieldnames or []
-        return [
+        header = list(reader.fieldnames or [])
+        rows = [
             (i, tuple(row[col] for col in header))
             for i, row in enumerate(reader, start=1)
         ]
+    return header, rows
 
 
 def _filter_unmatched(
@@ -39,19 +40,60 @@ def _filter_unmatched(
     return result
 
 
+def _similarity(a: tuple, b: tuple) -> float:
+    """Fraction of fields that match between two rows (0.0 – 1.0)."""
+    if not a and not b:
+        return 1.0
+    n = max(len(a), len(b))
+    matches = sum(x == y for x, y in zip(a, b))
+    return matches / n
+
+
+def _pair_closest(
+    exp_rows: list[tuple[int, tuple]],
+    act_rows: list[tuple[int, tuple]],
+) -> tuple[
+    list[tuple[tuple[int, tuple], tuple[int, tuple]]],  # paired (exp, act)
+    list[tuple[int, tuple]],  # unpaired expected
+    list[tuple[int, tuple]],  # unpaired actual
+]:
+    """Greedily pair rows from the smaller side with the closest match on the larger side."""
+    exp_is_smaller = len(exp_rows) <= len(act_rows)
+    smaller = exp_rows if exp_is_smaller else act_rows
+    remaining_larger = list(act_rows if exp_is_smaller else exp_rows)
+
+    pairs: list[tuple[tuple[int, tuple], tuple[int, tuple]]] = []
+    unpaired_smaller: list[tuple[int, tuple]] = []
+
+    for item in smaller:
+        if not remaining_larger:
+            unpaired_smaller.append(item)
+            continue
+        best_idx = max(
+            range(len(remaining_larger)),
+            key=lambda i: _similarity(item[1], remaining_larger[i][1]),
+        )
+        matched = remaining_larger.pop(best_idx)
+        pairs.append((item, matched) if exp_is_smaller else (matched, item))
+
+    unpaired_exp = unpaired_smaller if exp_is_smaller else remaining_larger
+    unpaired_act = remaining_larger if exp_is_smaller else unpaired_smaller
+    return pairs, unpaired_exp, unpaired_act
+
+
 def diff(expected_path: str, actual_path: str) -> list[str]:
-    exp_rows = load(expected_path)
-    act_rows = load(actual_path)
+    exp_header, exp_rows = load(expected_path)
+    _, act_rows = load(actual_path)
 
     exp_content = [row for _, row in exp_rows]
     act_content = [row for _, row in act_rows]
 
     exp_counter = Counter(exp_content)
     act_counter = Counter(act_content)
-    matched = exp_counter & act_counter  # rows present in both (min count)
+    matched = exp_counter & act_counter
 
-    unmatched_exp = exp_counter - matched  # rows only in expected
-    unmatched_act = act_counter - matched  # rows only in actual
+    unmatched_exp = exp_counter - matched
+    unmatched_act = act_counter - matched
 
     if not unmatched_exp and not unmatched_act:
         if exp_content != act_content:
@@ -60,7 +102,6 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
             ]
         return []
 
-    # Rebuild remaining unmatched rows in their original file order.
     remaining_exp = _filter_unmatched(exp_rows, unmatched_exp)
     remaining_act = _filter_unmatched(act_rows, unmatched_act)
 
@@ -70,19 +111,17 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
             f"Row count changed: {len(exp_content)} expected -> {len(act_content)} actual"
         )
 
-    # Merge both unmatched lists by post-filter index; exp before act when tied.
-    # Sort key: (post_filter_row, 0=Expected/1=Actual)
-    entries = [
-        (post_idx, 0, "Expected", src_lineno, row)
-        for post_idx, (src_lineno, row) in enumerate(remaining_exp, start=1)
-    ] + [
-        (post_idx, 1, "Actual", src_lineno, row)
-        for post_idx, (src_lineno, row) in enumerate(remaining_act, start=1)
-    ]
-    entries.sort(key=lambda e: (e[0], e[1]))
+    pairs, unpaired_exp, unpaired_act = _pair_closest(remaining_exp, remaining_act)
 
-    for _, _, label, src_lineno, row in entries:
-        diffs.append(f"  [{label:8}] Row {src_lineno}: {row}")
+    for (exp_lineno, exp_row), (act_lineno, act_row) in pairs:
+        diffs.append(f"  [Expected] Row {exp_lineno}: {exp_row}")
+        diffs.append(f"  [Actual  ] Row {act_lineno}: {act_row}")
+
+    for lineno, row in unpaired_exp:
+        diffs.append(f"  [Expected only] Row {lineno}: {row}")
+
+    for lineno, row in unpaired_act:
+        diffs.append(f"  [Actual only  ] Row {lineno}: {row}")
 
     return diffs
 

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -81,6 +81,36 @@ def _pair_closest(
     return pairs, unpaired_exp, unpaired_act
 
 
+def create_md_table(table_name, headers, records, property_getter=None):
+    """
+    Create a Markdown table with the given headers and records.
+
+    Args:
+        table_name: The title of the table
+        headers: List of column headers
+        records: List of records to include in the table
+        property_getter: Optional function to extract properties from records.
+                         If None, assumes records are dictionaries.
+    Returns:
+        String containing the formatted Markdown table
+    """
+    title = f"### {table_name}"
+    header = "| " + " | ".join(headers) + " |"
+    underline = "| " + " | ".join(["---" for _ in headers]) + " |"
+
+    if property_getter is None:
+
+        def property_getter(record, prop):
+            return str(record.get(prop, ""))
+
+    values = "\n".join(
+        "| " + " | ".join([property_getter(record, prop) for prop in headers]) + " |"
+        for record in records
+    )
+
+    return f"{title}\n\n{header}\n{underline}\n{values}"
+
+
 def diff(expected_path: str, actual_path: str) -> list[str]:
     exp_header, exp_rows = load(expected_path)
     _, act_rows = load(actual_path)
@@ -113,15 +143,29 @@ def diff(expected_path: str, actual_path: str) -> list[str]:
 
     pairs, unpaired_exp, unpaired_act = _pair_closest(remaining_exp, remaining_act)
 
+    table_headers = ["Exp/Act", "Result Row"] + exp_header
+
+    records = []
     for (exp_lineno, exp_row), (act_lineno, act_row) in pairs:
-        diffs.append(f"  [Expected] Row {exp_lineno}: {exp_row}")
-        diffs.append(f"  [Actual  ] Row {act_lineno}: {act_row}")
+        exp_record = {"Exp/Act": "Expected", "Result Row": str(exp_lineno)}
+        act_record = {"Exp/Act": "Actual",   "Result Row": str(act_lineno)}
+        for col, ev, av in zip(exp_header, exp_row, act_row):
+            exp_record[col] = f"**{ev}**" if ev != av else ev
+            act_record[col] = f"**{av}**" if ev != av else av
+        records.append(exp_record)
+        records.append(act_record)
 
     for lineno, row in unpaired_exp:
-        diffs.append(f"  [Expected only] Row {lineno}: {row}")
+        record = {"Exp/Act": "Expected only", "Result Row": str(lineno)}
+        record.update(zip(exp_header, row))
+        records.append(record)
 
     for lineno, row in unpaired_act:
-        diffs.append(f"  [Actual only  ] Row {lineno}: {row}")
+        record = {"Exp/Act": "Actual only", "Result Row": str(lineno)}
+        record.update(zip(exp_header, row))
+        records.append(record)
+
+    diffs.append(create_md_table("Diff Results", table_headers, records))
 
     return diffs
 

--- a/.github/scripts/diff_results.py
+++ b/.github/scripts/diff_results.py
@@ -19,11 +19,11 @@ from tabulate import tabulate
 
 def load(path: str) -> tuple[list[str], list[tuple[int, tuple]]]:
     """Return (header, [(1-based line number, row tuple)]), preserving original order."""
-    with open(path, newline="") as f:
+    with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         header = list(reader.fieldnames or [])
         rows = [
-            (i, tuple(row[col] for col in header))
+            (i, tuple(row[col].strip("\r") for col in header))
             for i, row in enumerate(reader, start=1)
         ]
     return header, rows

--- a/.github/scripts/run_validation.sh
+++ b/.github/scripts/run_validation.sh
@@ -157,7 +157,7 @@ for TEST_TYPE in positive negative; do
     (cd "$ENGINE_DIR" && $PYTHON_CMD core.py validate "${ENGINE_ARGS[@]}") \
       2>&1 | tee "$ENGINE_LOG" || ENGINE_EXIT=${PIPESTATUS[0]}
 
-    ACTUAL_CSV="$RESULTS_DIR/results.csv"
+    ACTUAL_CSV="$RESULTS_DIR/actual.csv"
 
     if [ $ENGINE_EXIT -ne 0 ] || [ ! -f "$ACTUAL_CSV" ]; then
       echo "  ERROR: engine failed or produced no output (exit $ENGINE_EXIT)"
@@ -175,7 +175,7 @@ for TEST_TYPE in positive negative; do
       emit_result "false" "" "" "false" "" "$ENGINE_LOG"
       FAILED_CASES=$((FAILED_CASES + 1))
       OVERALL_SUCCESS=false
-      [ "$MISSING_BASELINE" = false ] && mv "$EXPECTED_RESULTS" "$RESULTS_DIR/results.csv"
+      [ "$MISSING_BASELINE" = false ] && cp "$EXPECTED_RESULTS" "$RESULTS_DIR/results.csv"
       continue
     fi
 
@@ -234,7 +234,7 @@ for TEST_TYPE in positive negative; do
       OVERALL_SUCCESS=false
     fi
 
-    mv "$EXPECTED_RESULTS" "$RESULTS_DIR/results.csv"
+    cp "$EXPECTED_RESULTS" "$RESULTS_DIR/results.csv"
 
   done < <(find "$TYPE_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
 done

--- a/.github/scripts/run_validation.sh
+++ b/.github/scripts/run_validation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # run_validation.sh — iterates all positive/ and negative/ test cases for a rule,
-# runs the CORE engine against each, converts JSON output to results.csv,
+# runs the CORE engine against each, prints output to results.csv,
 # diffs against any expected results.csv, and writes two outputs:
 #   - $REPO_ROOT/validation_report.md  (detailed markdown, legacy/fallback)
 #   - $REPO_ROOT/case_results.jsonl    (one JSON line per test case for the summary table)

--- a/.github/scripts/run_validation.sh
+++ b/.github/scripts/run_validation.sh
@@ -157,7 +157,7 @@ for TEST_TYPE in positive negative; do
     (cd "$ENGINE_DIR" && $PYTHON_CMD core.py validate "${ENGINE_ARGS[@]}") \
       2>&1 | tee "$ENGINE_LOG" || ENGINE_EXIT=${PIPESTATUS[0]}
 
-    ACTUAL_CSV="$RESULTS_DIR/actual.csv"
+    ACTUAL_CSV="$RESULTS_DIR/results.csv"
 
     if [ $ENGINE_EXIT -ne 0 ] || [ ! -f "$ACTUAL_CSV" ]; then
       echo "  ERROR: engine failed or produced no output (exit $ENGINE_EXIT)"

--- a/.github/scripts/run_validation.sh
+++ b/.github/scripts/run_validation.sh
@@ -136,8 +136,8 @@ for TEST_TYPE in positive negative; do
     # Back up expected results.csv before the engine run (only if it exists)
     EXPECTED_RESULTS=""
     if [ "$MISSING_BASELINE" = false ]; then
-      cp "$RESULTS_DIR/results.csv" "$RESULTS_DIR/results.expected.csv"
-      EXPECTED_RESULTS="$RESULTS_DIR/results.expected.csv"
+      cp "$RESULTS_DIR/results.csv" "$RESULTS_DIR/expected.csv"
+      EXPECTED_RESULTS="$RESULTS_DIR/expected.csv"
     fi
 
     ENGINE_ARGS=(
@@ -204,6 +204,9 @@ for TEST_TYPE in positive negative; do
     $PYTHON_CMD "$SCRIPTS_DIR/diff_results.py" \
       "$EXPECTED_RESULTS" "$ACTUAL_CSV" "$CASE_LABEL" \
       > "$DIFF_LOG" 2>&1 || DIFF_EXIT=$?
+
+    # Preserve actual output before restoring the baseline
+    cp "$ACTUAL_CSV" "$RESULTS_DIR/actual.csv"
 
     if [ $DIFF_EXIT -eq 0 ]; then
       echo "  PASSED — actual results match expected baseline"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "diff_results: compare two CSVs",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/.github/scripts/diff_results.py",
+      "args": [
+        "${input:expectedCsv}",
+        "${input:actualCsv}",
+        "${input:caseLabel}"
+      ],
+      "console": "integratedTerminal"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "expectedCsv",
+      "type": "promptString",
+      "description": "Path to expected results CSV",
+      "default": "${workspaceFolder}/Published/CORE-000001/negative/01/results/expected.csv"
+    },
+    {
+      "id": "actualCsv",
+      "type": "promptString",
+      "description": "Path to actual results CSV",
+      "default": "${workspaceFolder}/Published/CORE-000001/negative/01/results/actual.csv"
+    },
+    {
+      "id": "caseLabel",
+      "type": "promptString",
+      "description": "Case label (e.g. negative/01)",
+      "default": "negative/01"
+    }
+  ]
+}


### PR DESCRIPTION
For Published rules testing, this improves the reporting of failed tests in the detailed report.
- Uses markdown table to display differences
- Aligns differences using closest row match instead of strictly row number
- Uploads both the expected and actual results to artifacts instead of only the expected results

Action run before update: https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/27967250482
Action run after update: https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/27973685763

Requires PR: https://github.com/cdisc-org/cdisc-rules-engine/pull/1769